### PR TITLE
Fix #5 to not set keybindings globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ UV Mode works automatically once installed. Simply open a Python file in a proje
 
 While automatic activation is the primary way to use UV Mode, you can also control it manually:
 
-- `C-c C-s`: Manually activate the virtual environment for the current project
-- `C-c C-u`: Deactivate the current virtual environment
+You can bind the commands `uv-mode-set` and `uv-mode-unset`, for example:
+
+```elisp
+;; Manually activate the virtual environment for the current project
+(define-key uv-mode-map (kbd "C-c C-s") #'uv-mode-set)
+;; Deactivate the current virtual environment
+(define-key uv-mode-map (kbd "C-c C-u") #'uv-mode-unset)
+```
 
 ### Mode Line Indicator
 

--- a/uv-mode.el
+++ b/uv-mode.el
@@ -83,18 +83,13 @@ This looks for a .venv directory in the project root."
   (setenv "VIRTUAL_ENV")
   (force-mode-line-update))
 
-(defvar uv-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-s") 'uv-mode-set)
-    (define-key map (kbd "C-c C-u") 'uv-mode-unset)
-    map)
+(defvar uv-mode-map (make-sparse-keymap)
   "Keymap for `uv-mode'.")
 
 ;;;###autoload
 (define-minor-mode uv-mode
   "Minor mode for uv virtualenv interaction.
 \\{uv-mode-map}"
-  :global t
   :lighter ""
   :keymap uv-mode-map
   (if uv-mode


### PR DESCRIPTION
This patch turns off the `global` flag for the minor mode and provides an empty keymap for the user to set their own bindings. Documentation updated as well.